### PR TITLE
fix CString memory leaks

### DIFF
--- a/misc/variadic/variadic_amd64.go
+++ b/misc/variadic/variadic_amd64.go
@@ -5,6 +5,7 @@
 package variadic
 
 /*
+#include <stdlib.h>
 #include <dlfcn.h>
 
 void *VariadicCall(void *ctx);
@@ -49,7 +50,9 @@ type FunctionCall struct {
 // used to call the C function named by the name parameter.
 func NewFunctionCall(name string) *FunctionCall {
 	fc := new(FunctionCall)
-	fc.addr = C.LookupSymAddr(C.CString(name))
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	fc.addr = C.LookupSymAddr(cname)
 	return fc
 }
 


### PR DESCRIPTION
`C.CString` allocates new memory with a copy of the string, so it also
needs to be freed after. This adds `C.free()` calls to free each
`C.CString()` allocated.

Fixes #53
