### PR TITLE
allow for custom protocol implementations to skip Has* methods

### DIFF
--- a/objc/protocol.go
+++ b/objc/protocol.go
@@ -315,6 +315,11 @@ func respondsTo(goID uintptr, sel unsafe.Pointer) bool {
 	if mi.required {
 		return true
 	}
+	// invalid hasFunc means no HasXXX method, but the XXX method does exist.
+	// this indicates the optional method is implemented by this implementation.
+	if !mi.hasFunc.IsValid() {
+		return true
+	}
 
 	return mi.hasFunc.Call([]reflect.Value{v})[0].Bool()
 }


### PR DESCRIPTION
_Please consider this change carefully - I'm not so familiar with the implications._

In experimenting with implementing a protocol using a custom struct, I found that for optional methods, the `HasXXX` method was required. This change makes it such that if the method `XXX` is implemented, but the corresponding `HasXXX` is not implemented, the method/selector is considered to be implemented.

This came out of me exploring the tableview example. Here's a significantly simpler version of the example (albeit without the dynamically changing data) using a custom `NSTableViewDataSource` implementation:

https://gist.github.com/daaku/be2cd99b492cfc75ba1efe23ca56acd0