### PR TITLE
Patch: fix missing block type encoding and respondsTo panic

### DIFF
--- a/objc/protocol.go
+++ b/objc/protocol.go
@@ -311,11 +311,15 @@ func respondsTo(goID uintptr, sel unsafe.Pointer) bool {
 		return false
 	}
 
-	v := reflect.ValueOf(ii.instance)
 	if mi.required {
 		return true
 	}
 
+	if !mi.hasFunc.IsValid() {
+		return true
+	}
+
+	v := reflect.ValueOf(ii.instance)
 	return mi.hasFunc.Call([]reflect.Value{v})[0].Bool()
 }
 

--- a/objc/type_convertion.m
+++ b/objc/type_convertion.m
@@ -46,7 +46,7 @@ void* to_ns_array(array array) {
 
 array to_c_array(void* ptr) {
     NSArray* result_ = (NSArray*)ptr;
-    array result_Array;
+    array result_Array = {0};
     int result_count = [result_ count];
     if (result_count > 0) {
         void** result_Data = malloc(result_count * sizeof(void*));

--- a/objc/type_encodings.go
+++ b/objc/type_encodings.go
@@ -44,6 +44,8 @@ func getTypeEncoding(t reflect.Type) string {
 			return "^" + getTypeEncoding(t.Elem())
 		}
 
+	case reflect.Func:
+		return "@?" // ObjC block
 	case reflect.String, reflect.Slice, reflect.Map:
 		return "@"
 	case reflect.Array:


### PR DESCRIPTION
- type_encodings.go: add reflect.Func -> "@?" for ObjC block parameters
- protocol.go: return true for optional methods without Has* function instead of panicking on zero reflect.Value