### PR TITLE
objc/ffi: keep CIF arg types alive for the closure's lifetime

### DIFF
--- a/objc/ffi/ffi.go
+++ b/objc/ffi/ffi.go
@@ -65,10 +65,30 @@ func MakeStructType(types []*Type) *Type {
 
 func PrepCIF(rtype *Type, argtypes []*Type) (*CIF, Status) {
 	var cif CIF
+	// ffi_prep_cif stores rtype and the address of argtypes' backing array
+	// inside the CIF (cif->rtype and cif->arg_types) for as long as the CIF
+	// -- and any closure built from it -- stays in use, which for a closure
+	// can be well after this call returns (e.g. an AppKit delegate callback
+	// firing long after the closure was created). runtime.KeepAlive only
+	// kept them alive through this call, not past it, so once Go 1.25's
+	// smarter escape analysis started stack-allocating argtypes' backing
+	// array instead of heap-allocating it, that memory got reused/clobbered
+	// before the closure ever fired (progrium/darwinkit#286); a
+	// heap-allocated rtype (e.g. from MakeStructType) is exposed to the same
+	// risk once nothing else references it. Wrapping both in a cgo.Handle
+	// forces them onto the heap and keeps a live Go reference for as long as
+	// the CIF is reachable; the finalizer below drops that reference once
+	// the CIF itself is no longer needed.
+	retained := cgo.NewHandle(struct {
+		rtype    *Type
+		argtypes []*Type
+	}{rtype, argtypes})
 	s := C.ffi_prep_cif0(toUintptrT(&cif), DEFAULT_ABI, C.uint(len(argtypes)), toUintptrT(rtype), toUintptrT(&argtypes[0]))
-	runtime.KeepAlive(rtype)
-	runtime.KeepAlive(argtypes)
-	return &cif, s
+	cifPtr := &cif
+	runtime.SetFinalizer(cifPtr, func(*CIF) {
+		retained.Delete()
+	})
+	return cifPtr, s
 }
 
 func Call(cif *CIF, fn unsafe.Pointer, rvalue unsafe.Pointer, avalues []unsafe.Pointer) {


### PR DESCRIPTION
Fixes #286.

`ffi_prep_cif` stores `rtype` and the address of `argtypes`' backing
array inside the CIF for as long as the CIF is used. A closure built
from that CIF (via `CreateClosure`) can be invoked long after
`PrepCIF` returns, once an AppKit delegate callback fires, but nothing
kept either value alive past the call itself. `runtime.KeepAlive` only
extends liveness through the call it's in, not beyond it.

Go 1.25's smarter escape analysis started stack-allocating the
`argtypes` array at the call sites in `call.go`, `block.go`,
`protocol.go`, and `type_convertion.go`, instead of heap-allocating it
as earlier Go versions happened to. Once stack-allocated, that memory
gets reused before the closure fires, so `cif->arg_types` ends up
pointing at garbage. macOS 26's `libffi.dylib` added a stricter
`arg_types[i]->type > 15` check that turns this into a reproducible
`SIGABRT` on launch, in the very first delegate callback
(`applicationDidFinishLaunching:`). Full disassembly-level detail is
in the issue thread.

This wraps `rtype` and `argtypes` in a `cgo.Handle` stored alongside
the CIF, so both stay reachable for as long as the CIF itself does,
and deletes that handle once the CIF is garbage collected via
`runtime.SetFinalizer`. Passing them through a `cgo.Handle` also forces
them onto the heap, which is what closes off the escape-analysis path
that caused the bug.

I considered copying `argtypes` into `malloc`'d C memory instead (an
option floated in the issue), but that would store Go pointers
(including ones from `MakeStructType`) in memory the Go GC doesn't
scan, which is itself a cgo pointer-passing rule violation. The
`cgo.Handle` approach avoids that.

Verification:

- `go build -gcflags='github.com/progrium/darwinkit/objc=-m' ./objc/...`
  shows the flip this fix is meant to produce: before, `make([]*ffi...)`
  at all five affected call sites reports "does not escape"; after, all
  five report "escapes to heap".
- `go test ./objc/...` passes, `go vet ./objc/...` is clean, `gofmt -l`
  reports no changes needed on the touched files.
- Reproduced the actual crash against a real long-lived AppKit app (a
  status-bar menu app using a closure-based `NSApplicationDelegate`) on
  Go 1.26.1, macOS 26.5 arm64: it reliably `SIGABRT`s on launch without
  this fix and without the `-gcflags "all=-N"` workaround, and launches
  and stays running with this fix applied and that workaround removed.
